### PR TITLE
Spring Security 설정 추가

### DIFF
--- a/apps/spring-security-ex1/src/main/java/com/villainscode/study/config/SecurityConfig.java
+++ b/apps/spring-security-ex1/src/main/java/com/villainscode/study/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.villainscode.study.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/blog/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(formLogin -> formLogin
+                        .loginPage("/login")
+                        .permitAll()
+                )
+                .rememberMe(Customizer.withDefaults());
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
Spring Security를 사용하여 애플리케이션의 보안을 설정했습니다.

주요 변경사항:
1. SecurityConfig 클래스 추가
2. Configuration 및 EnableWebSecurity 어노테이션 사용
3. SecurityFilterChain 빈 정의
4. /blog/** 경로에 대한 접근 허용
5. 나머지 요청에 대해 인증 요구
6. 사용자 로그인 페이지 설정
7. Remember Me 기능 기본 설정